### PR TITLE
Fix dragonite-java fix

### DIFF
--- a/data/dragonite-java/misuses/2/correct-usages/AES.java
+++ b/data/dragonite-java/misuses/2/correct-usages/AES.java
@@ -1,9 +1,0 @@
-import javax.crypto.spec.IvParameterSpec;
-import java.security.SecureRandom;
-
-public class ConstructRandomizedIV{
-	public void pattern(int offset, int len) {
-		SecureRandom random = SecureRandom();
-		IVParameterSpec iv = new IvParameterSpec(random);
-	}
-}

--- a/data/dragonite-java/misuses/2/correct-usages/ConstructIvParameterSpec.java
+++ b/data/dragonite-java/misuses/2/correct-usages/ConstructIvParameterSpec.java
@@ -1,0 +1,11 @@
+import javax.crypto.spec.IvParameterSpec;
+import java.security.SecureRandom;
+
+public class ConstructIvParameterSpec {
+    public void pattern() {
+	SecureRandom iv = new SecureRandom(); 
+	byte bytes[] = new byte[100];
+	iv.nextBytes(bytes);
+	IvParameterSpec ips = new IvParameterSpec(bytes);
+    }
+}


### PR DESCRIPTION
Hi, I've been taking a look at the correct usages portion of your parametric JCA misuses contribution to MUBench (I am interested in using them for some work I am doing), and I came across one fix that contained an error:

Previous fix did not compile.
To remedy: replaced with fix for
instagram4j misuse#1 fix, since this
was the same type of misuse

Please take a look and let me know if you have any suggestions on how you'd rather have this problem solved!