### PR TITLE
Fix whatsmars misplaced corrections

### DIFF
--- a/data/whatsmars/misuses/10/correct-usages/ConstructCipher.java
+++ b/data/whatsmars/misuses/10/correct-usages/ConstructCipher.java
@@ -1,8 +1,0 @@
-import javax.crypto.Cipher;
-import java.security.NoSuchAlgorithmException;
-
-public class ConstructCipher {
-	public void pattern() throws Exception{
-	      Cipher c = Cipher.getInstance("PBEWithHmacSHA224AndAES_128");
-	}
-}

--- a/data/whatsmars/misuses/10/correct-usages/ConstructSecretKeySpec.java
+++ b/data/whatsmars/misuses/10/correct-usages/ConstructSecretKeySpec.java
@@ -1,0 +1,17 @@
+import javax.crypto.spec.SecretKeySpec;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.PBEKeySpec;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+
+public class ConstructSecretKeySpec {
+		public void pattern(char[] password,byte[] salt,int iterationCount,int keylength,java.lang.String algorithm) throws Exception {
+		SecretKeyFactory skf = SecretKeyFactory.getInstance("PBEWithHmacSHA512AndAES_128");
+		PBEKeySpec pbeks = new PBEKeySpec(password, salt, iterationCount, keylength);
+		SecretKey key =  skf.generateSecret(pbeks);
+		byte[] keyMaterial = key.getEncoded();
+		SecretKeySpec sks = new SecretKeySpec(keyMaterial, algorithm);
+	}
+}
+

--- a/data/whatsmars/misuses/11/correct-usages/ConstructCipher.java
+++ b/data/whatsmars/misuses/11/correct-usages/ConstructCipher.java
@@ -1,8 +1,0 @@
-import javax.crypto.Cipher;
-import java.security.NoSuchAlgorithmException;
-
-public class ConstructCipher {
-	public void pattern() throws Exception{
-	      Cipher c = Cipher.getInstance("PBEWithHmacSHA224AndAES_128");
-	}
-}

--- a/data/whatsmars/misuses/11/correct-usages/ConstructSecretKeySpec.java
+++ b/data/whatsmars/misuses/11/correct-usages/ConstructSecretKeySpec.java
@@ -1,0 +1,17 @@
+import javax.crypto.spec.SecretKeySpec;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.PBEKeySpec;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+
+public class ConstructSecretKeySpec {
+		public void pattern(char[] password,byte[] salt,int iterationCount,int keylength,java.lang.String algorithm) throws Exception {
+		SecretKeyFactory skf = SecretKeyFactory.getInstance("PBEWithHmacSHA512AndAES_128");
+		PBEKeySpec pbeks = new PBEKeySpec(password, salt, iterationCount, keylength);
+		SecretKey key =  skf.generateSecret(pbeks);
+		byte[] keyMaterial = key.getEncoded();
+		SecretKeySpec sks = new SecretKeySpec(keyMaterial, algorithm);
+	}
+}
+


### PR DESCRIPTION
Previously correct-usage file for
whatsmars misuse 10 & 11 contained
a correct pattern for insecure parameter
to cipher object type of misuse, however
the 10 & 11 yml file lists misuse as the following:
First parameter while initializing SecretKeySpec
was not properly randomized.

Replaced the correct-usages files
with the same solution as for whatsmars
misuse 6, because these are the same misuse issue.

This looks to me to be a simple file misplacement issue, the fix is also simple , 
but let me know if you would like it addressed in any other way :)